### PR TITLE
Add flag NEXT_ON_MULTIPLEX

### DIFF
--- a/include/fcgiapp.h
+++ b/include/fcgiapp.h
@@ -82,6 +82,7 @@ typedef char **FCGX_ParamArray;
  * restarting upon being interrupted.
  */
 #define FCGI_FAIL_ACCEPT_ON_INTR	1
+#define NEXT_ON_MULTIPLEX	2
 
 /*
  * FCGX_Request -- State associated with a request.

--- a/libfcgi/fcgiapp.c
+++ b/libfcgi/fcgiapp.c
@@ -1531,7 +1531,7 @@ static int ProcessBeginRecord(int requestId, FCGX_Stream *stream)
     if(requestId == 0 || data->contentLen != sizeof(body)) {
         return FCGX_PROTOCOL_ERROR;
     }
-    if(data->reqDataPtr->isBeginProcessed) {
+    if(data->reqDataPtr->isBeginProcessed && !(data->reqDataPtr->flags & NEXT_ON_MULTIPLEX)) {
         /*
          * The Web server is multiplexing the connection.  This library
          * doesn't know how to handle multiplexing, so respond with

--- a/perl/FCGI.pm
+++ b/perl/FCGI.pm
@@ -9,6 +9,7 @@ BEGIN {
 }
 
 sub FAIL_ACCEPT_ON_INTR () { 1 };
+sub NEXT_ON_MULTIPLEX () { 2 };
 
 sub Request(;***$*$) {
     my @defaults = (\*STDIN, \*STDOUT, \*STDERR, \%ENV, 0, FAIL_ACCEPT_ON_INTR);
@@ -137,6 +138,13 @@ Possible values:
 
 If set, Accept will fail if interrupted.
 It not set, it will just keep on waiting.
+
+=back
+
+=item FCGI::NEXT_ON_MULTIPLEX
+
+If set, do not wait message with current requestId, start processing next request
+It not set, wait finishing current request with correct requestId - this can produce lot of 500 errors with IIS
 
 =back
 


### PR DESCRIPTION
Fix problem with IIS server and high load:
https://rt.cpan.org/Public/Bug/Display.html?id=82068
https://rt.cpan.org/Public/Bug/Display.html?id=120340

Maybe easier make this behavior default and just remove  if(data->reqDataPtr->isBeginProcessed) {...}