### PR TITLE
Fix a memory leak in ProcessManagementRecord()

### DIFF
--- a/libfcgi/fcgiapp.c
+++ b/libfcgi/fcgiapp.c
@@ -1454,13 +1454,14 @@ static void EmptyBuffProc(struct FCGX_Stream *stream, int doClose)
 static int ProcessManagementRecord(int type, FCGX_Stream *stream)
 {
     FCGX_Stream_Data *data = (FCGX_Stream_Data *)stream->data;
-    ParamsPtr paramsPtr = NewParams(3);
+    ParamsPtr paramsPtr;
     char **pPtr;
     char response[64]; /* 64 = 8 + 3*(1+1+14+1)* + padding */
     char *responseP = &response[FCGI_HEADER_LEN];
     char *name, value = '\0';
     int len, paddedLen;
     if(type == FCGI_GET_VALUES) {
+        paramsPtr = NewParams(3);
         ReadParams(paramsPtr, stream);
         if((FCGX_GetError(stream) != 0) || (data->contentLen != 0)) {
             FreeParams(&paramsPtr);


### PR DESCRIPTION
paramsPtr variable was always allocated but freed only if type was
FCGI_GET_VALUES. In other cases the variable leaked. This patch fixes
it.