### PR TITLE
Add dependency to FCGI::Client 0.09

### DIFF
--- a/perl/ChangeLog
+++ b/perl/ChangeLog
@@ -1,5 +1,8 @@
 Release history for FCGI
 
+  - Add dependency to FCGI::Client 0.09 because not depend on Any::Moose,
+  which is deprecated.
+
 Version 0.80 --  2021-07-24
 
   - Add test for FCGI over unix domain socket (Michal Josef Špaček, PR #6)

--- a/perl/Makefile.PL
+++ b/perl/Makefile.PL
@@ -138,7 +138,7 @@ WriteMakefile(
     PM            => {'FCGI.pm' => '$(INST_ARCHLIBDIR)/FCGI.pm'},
     PREREQ_PM     => {'XSLoader' => '0'},
     TEST_REQUIRES => {
-        'FCGI::Client' => 0,
+        'FCGI::Client' => 0.09,
         'File::Temp' => 0,
         'IO::Socket::UNIX' => 0,
         'Test::More' => 0,


### PR DESCRIPTION
Add dependency to FCGI::Client 0.09 because not depend on Any::Moose,
which is deprecated